### PR TITLE
fix: adapt dashboard cards to active theme

### DIFF
--- a/package/luci-mod-fluentdashboard/Makefile
+++ b/package/luci-mod-fluentdashboard/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-mod-fluentdashboard
 PKG_VERSION:=1.0.9
-PKG_RELEASE:=1
+PKG_RELEASE:=4
 PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=LazuliKao
 PKGARCH:=all

--- a/package/luci-mod-fluentdashboard/htdocs/luci-static/resources/view/fluentdashboard/index.css
+++ b/package/luci-mod-fluentdashboard/htdocs/luci-static/resources/view/fluentdashboard/index.css
@@ -1,8 +1,9 @@
 .fluent-dashboard {
-  --fluent-dashboard-border: color-mix(in srgb, currentColor 16%, transparent);
-  --fluent-dashboard-muted: color-mix(in srgb, currentColor 68%, transparent);
-  --fluent-dashboard-surface: color-mix(in srgb, Canvas 96%, currentColor 4%);
-  color: canvastext;
+  --fluent-dashboard-border: var(--fluent-card-border, var(--inputborder-color, color-mix(in srgb, currentColor 16%, transparent)));
+  --fluent-dashboard-muted: var(--fluent-text-secondary, color-mix(in srgb, currentColor 68%, transparent));
+  --fluent-dashboard-surface: var(--fluent-card-bg, rgba(var(--primary-rgbbody, 255, 255, 255), 0.7));
+  --fluent-dashboard-shadow: var(--fluent-card-shadow, 0 .1rem .3rem var(--input-boxcolor, color-mix(in srgb, CanvasText 8%, transparent)));
+  color: var(--fluent-text, CanvasText);
   container-type: inline-size;
 }
 
@@ -20,7 +21,9 @@
   margin-block-end: 1rem;
   padding: 1.25rem;
   display: flex;
+  z-index: 0;
   overflow: hidden;
+  position: relative;
 }
 
 .fluent-dashboard__header h1, .fluent-dashboard__header p {
@@ -55,7 +58,7 @@
   color: inherit;
   background: var(--fluent-dashboard-surface);
   border: 1px solid var(--fluent-dashboard-border);
-  box-shadow: 0 .25rem 1rem color-mix(in srgb, CanvasText 8%, transparent);
+  box-shadow: var(--fluent-dashboard-shadow);
   border-radius: .75rem;
   overflow: hidden;
 }

--- a/src/web/fluentdashboard/index.css
+++ b/src/web/fluentdashboard/index.css
@@ -1,8 +1,9 @@
 .fluent-dashboard {
-  --fluent-dashboard-border: color-mix(in srgb, currentColor 16%, transparent);
-  --fluent-dashboard-muted: color-mix(in srgb, currentColor 68%, transparent);
-  --fluent-dashboard-surface: color-mix(in srgb, Canvas 96%, currentColor 4%);
-  color: CanvasText;
+  --fluent-dashboard-border: var(--fluent-card-border, var(--inputborder-color, color-mix(in srgb, currentColor 16%, transparent)));
+  --fluent-dashboard-muted: var(--fluent-text-secondary, color-mix(in srgb, currentColor 68%, transparent));
+  --fluent-dashboard-surface: var(--fluent-card-bg, rgba(var(--primary-rgbbody, 255, 255, 255), 0.7));
+  --fluent-dashboard-shadow: var(--fluent-card-shadow, 0 0.1rem 0.3rem var(--input-boxcolor, color-mix(in srgb, CanvasText 8%, transparent)));
+  color: var(--fluent-text, CanvasText);
   container-type: inline-size;
 }
 
@@ -18,8 +19,10 @@
   gap: 1rem;
   margin-block-end: 1rem;
   padding: 1.25rem;
+  z-index: 0;
   overflow: hidden;
   color: HighlightText;
+  position: relative;
   background: linear-gradient(120deg, Highlight, color-mix(in srgb, Highlight 68%, CanvasText));
   border-radius: 0.75rem;
 }
@@ -59,7 +62,7 @@
   background: var(--fluent-dashboard-surface);
   border: 1px solid var(--fluent-dashboard-border);
   border-radius: 0.75rem;
-  box-shadow: 0 0.25rem 1rem color-mix(in srgb, CanvasText 8%, transparent);
+  box-shadow: var(--fluent-dashboard-shadow);
 }
 
 .fluent-dashboard__card--wide {


### PR DESCRIPTION
## Summary
- derive FluentDashboard card surfaces, borders, text, and shadows from Fluent theme tokens
- retain compatible fallbacks for KuCat and other LuCI themes
- keep the dashboard hero below theme navigation overlays
- bump `luci-mod-fluentdashboard` release to 4

#### Test plan
- [x] Verified card surfaces and text against KuCat dark mode on OpenWrt
- [x] Verified dashboard navigation and layout after live deployment
- [x] Checked source and generated CSS with `git diff --check`
- [ ] Run Biome in CI (local dependencies are not installed)

Generated with [Devin](https://devin.ai)